### PR TITLE
Updating compromised version of Trivy

### DIFF
--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Run Aqua Trivy scan
         id: trivy-scan
         if: ${{ matrix.target == 'production' }}
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           image-ref: ${{steps.setImageDetails.outputs.fullImageName}}
           format: sarif

--- a/.github/workflows/nightly-scan.yml
+++ b/.github/workflows/nightly-scan.yml
@@ -41,7 +41,7 @@ jobs:
       
       - name: Run Aqua Trivy scan
         id: trivy-scan
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           image-ref: defradigital/${{env.IMAGE_NAME}}:${{env.DEFRA_VERSION}}-java${{matrix.image.runTimeVersion}}
           format: sarif


### PR DESCRIPTION
# Description

Ref Trivy compromise https://socket.dev/blog/trivy-under-attack-again-github-actions-compromise

Pinning to later version.